### PR TITLE
Save device pretty name to picture metadata

### DIFF
--- a/src/capture/CaptureView.qml
+++ b/src/capture/CaptureView.qml
@@ -665,7 +665,7 @@ FocusScope {
 
         metaData {
             orientation: captureView.captureOrientation
-            cameraModel: deviceInfo.model
+            cameraModel: deviceInfo.prettyName
             cameraManufacturer: deviceInfo.manufacturer
         }
 


### PR DESCRIPTION
For Jolla C2 for example camera model changes from `s19mps` to `Jolla C2` in picture metadata.