### PR TITLE
Fix selfie action

### DIFF
--- a/camera.cpp
+++ b/camera.cpp
@@ -18,7 +18,6 @@
 #include <MDeclarativeCache>
 #endif
 
-
 Q_DECL_EXPORT int main(int argc, char *argv[])
 {
     QQuickWindow::setDefaultAlphaBuffer(true);
@@ -37,7 +36,6 @@ Q_DECL_EXPORT int main(int argc, char *argv[])
 
     view->setSource(path + QLatin1String("camera.qml"));
     //% "Camera"
-    QT_TRID_NOOP("jolla-camera-ap-name");
     view->setTitle(qtTrId("jolla-camera-ap-name"));
 
     if (app->arguments().contains("-desktop")) {

--- a/pages/MainCameraPage.qml
+++ b/pages/MainCameraPage.qml
@@ -66,8 +66,8 @@ CameraPage {
             if (switchToImageMode) {
                 Settings.global.captureMode = "image"
             }
-            if (Settings.frontFacingDeviceId >= 0) {
-                Settings.deviceId = Settings.frontFacingDeviceId
+            if (Settings.global.frontFacingDeviceId !== "") {
+                Settings.deviceId = Settings.global.frontFacingDeviceId
             } else {
                 console.warn("No front camera detected")
             }

--- a/src/cameraconfigs.cpp
+++ b/src/cameraconfigs.cpp
@@ -4,6 +4,7 @@
 // SPDX-License-Identifier: BSD-3-Clause
 
 #include "cameraconfigs.h"
+
 #include <QCamera>
 #include <QMediaRecorder>
 #include <QCameraImageCapture>

--- a/src/cameraconfigs.h
+++ b/src/cameraconfigs.h
@@ -45,7 +45,7 @@ public:
 
     Q_ENUM(AspectRatio)
 
-    CameraConfigs(QObject *parent = 0);
+    CameraConfigs(QObject *parent = nullptr);
     ~CameraConfigs();
 
     QList<QObject *> exposedItems() const;
@@ -81,10 +81,12 @@ signals:
     void supportedFocusPointModesChanged();
     void supportedMeteringModesChanged();
     void supportedFlashModesChanged();
+
 private slots:
     void handleStatus();
     void handleState();
     void handleCaptureMode();
+
 private:
     bool m_ready = false;
     QCamera *m_camera = nullptr;
@@ -103,4 +105,3 @@ private:
 };
 
 #endif // CAMERACONFIGS_H
-

--- a/src/capture/CaptureView.qml
+++ b/src/capture/CaptureView.qml
@@ -476,7 +476,6 @@ FocusScope {
         }
 
         property bool hasCameraOnBothSides
-        property string frontFacingDeviceId
         property var backFacingCameras
 
         // On some adaptations media booster makes camera initialization fail
@@ -547,7 +546,7 @@ FocusScope {
                     var device = QtMultimedia.availableCameras[i]
                     if (!hasFrontFace && device.position === Camera.FrontFace) {
                         hasFrontFace = true
-                        frontFacingDeviceId = device.deviceId
+                        Settings.global.frontFacingDeviceId = device.deviceId
                     } else if (device.position === Camera.BackFace) {
                         hasBackFace = true
                         backCameras.push(device)

--- a/src/capturemodel.h
+++ b/src/capturemodel.h
@@ -25,13 +25,14 @@ class CaptureModel : public QAbstractListModel, public QQmlParserStatus
     Q_PROPERTY(bool populated READ isPopulated NOTIFY populatedChanged)
     Q_PROPERTY(QStringList directories READ directories WRITE setDirectories NOTIFY directoriesChanged)
     Q_PROPERTY(int count READ count NOTIFY countChanged)
+
 public:
     enum {
         Url,
         MimeType
     };
 
-    CaptureModel(QObject *parent = 0);
+    CaptureModel(QObject *parent = nullptr);
     ~CaptureModel() override;
 
     bool isPopulated() const;
@@ -51,7 +52,6 @@ public:
 
     void classBegin() override;
     void componentComplete() override;
-
 
 signals:
     void populatedChanged();

--- a/src/declarativecameraextensions.h
+++ b/src/declarativecameraextensions.h
@@ -13,8 +13,9 @@
 class DeclarativeCameraExtensions : public QObject
 {
     Q_OBJECT
+
 public:
-    DeclarativeCameraExtensions(QObject *parent = 0);
+    DeclarativeCameraExtensions(QObject *parent = nullptr);
     ~DeclarativeCameraExtensions();
 
     Q_INVOKABLE void disableNotifications(QQuickItem *item, bool disable);

--- a/src/declarativesettings.cpp
+++ b/src/declarativesettings.cpp
@@ -46,7 +46,6 @@ DeclarativeSettings::DeclarativeSettings(QObject *parent)
 
 DeclarativeSettings::~DeclarativeSettings()
 {
-
 }
 
 QObject *DeclarativeSettings::factory(QQmlEngine *engine, QJSEngine *)
@@ -58,7 +57,8 @@ QObject *DeclarativeSettings::factory(QQmlEngine *engine, QJSEngine *)
     } else {
         qWarning() << "Failed to instantiate Settings";
         qWarning() << component.errors();
-        return 0;
+
+        return nullptr;
     }
 }
 

--- a/src/declarativesettings.h
+++ b/src/declarativesettings.h
@@ -30,8 +30,9 @@ class DeclarativeSettings : public QObject
     Q_PROPERTY(qint64 storageMaxFileSize READ storageMaxFileSize NOTIFY storageMaxFileSizeChanged)
     Q_PROPERTY(StoragePathStatus storagePathStatus READ storagePathStatus NOTIFY storagePathStatusChanged)
     Q_ENUMS(StoragePathStatus)
+
 public:
-    DeclarativeSettings(QObject *parent = 0);
+    DeclarativeSettings(QObject *parent = nullptr);
     ~DeclarativeSettings();
 
     static QObject *factory(QQmlEngine *, QJSEngine *);
@@ -89,4 +90,3 @@ private:
 };
 
 #endif
-

--- a/src/settings.qml
+++ b/src/settings.qml
@@ -52,6 +52,7 @@ SettingsBase {
         // Note! don't touch this for changing between cameras, see cameraDevice on root
         property string deviceId
         property string previousBackFacingDeviceId
+        property string frontFacingDeviceId
         property int position: Camera.BackFace
         property string captureMode: "image"
 

--- a/src/settings/SettingsOverlay.qml
+++ b/src/settings/SettingsOverlay.qml
@@ -162,7 +162,7 @@ PinchArea {
         visible: opacity > 0.0
                  && !!model && model.length > 1
                  && labels.length > 0
-                 && Settings.deviceId !== camera.frontFacingDeviceId
+                 && Settings.deviceId !== Settings.global.frontFacingDeviceId
                  && !inButtonLayout
         orientation: overlay.isPortrait ? Qt.Horizontal : Qt.Vertical
         enabled: camera.cameraStatus === Camera.ActiveStatus
@@ -193,7 +193,7 @@ PinchArea {
         anchors.centerIn: parent
         onClicked: {
             if (Settings.global.position === Camera.BackFace) {
-                Settings.deviceId = camera.frontFacingDeviceId
+                Settings.deviceId = Settings.global.frontFacingDeviceId
             } else {
                 Settings.deviceId = Settings.global.previousBackFacingDeviceId
             }

--- a/src/settings/SettingsOverlay.qml
+++ b/src/settings/SettingsOverlay.qml
@@ -304,7 +304,8 @@ PinchArea {
                     overlay.topMenuOpen = false
                 }
                 // don't react near display edges
-                if (outOfBounds(mouseX, mouseY)) return
+                if (outOfBounds(mouseX, mouseY))
+                    return
                 if (whiteBalanceMenu.expanded) {
                     whiteBalanceMenu.open = false
                 } else if (overlay.inButtonLayout) {


### PR DESCRIPTION
From commit message:

    Looks like a regression in commit abe4f36687e8 which heavily modified
    the camera setup. Halfway assuming the secondary camera id is found
    from settings but then adding it inside a subview.
