### PR TITLE
Add startup timing markers.

### DIFF
--- a/camera.cpp
+++ b/camera.cpp
@@ -6,10 +6,25 @@
 #include <QDir>
 #include <QTranslator>
 #include <QLocale>
+#include <QElapsedTimer>
+#include <QDebug>
 
 #include <QGuiApplication>
 #include <QQmlEngine>
 #include <QQmlContext>
+
+static bool cameraStartupLoggingEnabled()
+{
+    static const bool enabled = !qgetenv("CAMERA_STARTUP_LOG").isEmpty();
+    return enabled;
+}
+
+#define CAMERA_STARTUP_MARK(scope, timer, format, ...) \
+    do { \
+        if (cameraStartupLoggingEnabled()) \
+            qInfo("CAMERA_STARTUP " scope " %lld ms " format, \
+                  static_cast<long long>((timer).elapsed()), ##__VA_ARGS__); \
+    } while (false)
 #include <QQuickItem>
 #include <QQuickView>
 #include <QQmlComponent>
@@ -20,6 +35,10 @@
 
 Q_DECL_EXPORT int main(int argc, char *argv[])
 {
+    QElapsedTimer startupTimer;
+    startupTimer.start();
+    CAMERA_STARTUP_MARK("app", startupTimer, "main entered");
+
     QQuickWindow::setDefaultAlphaBuffer(true);
 
 #ifdef HAS_BOOSTER
@@ -33,8 +52,8 @@ Q_DECL_EXPORT int main(int argc, char *argv[])
     QString path(QLatin1String(DEPLOYMENT_PATH));
 
     view->engine()->setBaseUrl(QUrl::fromLocalFile(path));
-
     view->setSource(path + QLatin1String("camera.qml"));
+    CAMERA_STARTUP_MARK("app", startupTimer, "camera.qml loaded status=%d", view->status());
     //% "Camera"
     view->setTitle(qtTrId("jolla-camera-ap-name"));
 
@@ -42,9 +61,10 @@ Q_DECL_EXPORT int main(int argc, char *argv[])
         view->resize(480, 854);
         view->rootObject()->setProperty("_desktop", true);
         view->show();
+        CAMERA_STARTUP_MARK("app", startupTimer, "desktop window shown");
     } else {
         view->showFullScreen();
+        CAMERA_STARTUP_MARK("app", startupTimer, "fullscreen window shown");
     }
-
     return app->exec();
 }

--- a/lockscreen/main.cpp
+++ b/lockscreen/main.cpp
@@ -6,10 +6,25 @@
 #include <QDir>
 #include <QTranslator>
 #include <QLocale>
+#include <QElapsedTimer>
+#include <QDebug>
 
 #include <QGuiApplication>
 #include <QQmlEngine>
 #include <QQmlContext>
+
+static bool cameraStartupLoggingEnabled()
+{
+    static const bool enabled = !qgetenv("CAMERA_STARTUP_LOG").isEmpty();
+    return enabled;
+}
+
+#define CAMERA_STARTUP_MARK(scope, timer, format, ...) \
+    do { \
+        if (cameraStartupLoggingEnabled()) \
+            qInfo("CAMERA_STARTUP " scope " %lld ms " format, \
+                  static_cast<long long>((timer).elapsed()), ##__VA_ARGS__); \
+    } while (false)
 #include <QQuickItem>
 #include <QQuickView>
 #include <QQmlComponent>
@@ -21,6 +36,10 @@
 
 Q_DECL_EXPORT int main(int argc, char *argv[])
 {
+    QElapsedTimer startupTimer;
+    startupTimer.start();
+    CAMERA_STARTUP_MARK("lockscreen-app", startupTimer, "main entered");
+
     QQuickWindow::setDefaultAlphaBuffer(true);
 
 #ifdef HAS_BOOSTER
@@ -36,6 +55,7 @@ Q_DECL_EXPORT int main(int argc, char *argv[])
     view->engine()->setBaseUrl(QUrl::fromLocalFile(path));
 
     view->setSource(path + QLatin1String("lockscreen.qml"));
+    CAMERA_STARTUP_MARK("lockscreen-app", startupTimer, "lockscreen.qml loaded status=%d", view->status());
     view->setTitle(qtTrId("jolla-camera-ap-name"));
 
     QObject::connect(view->engine(), &QQmlEngine::quit, app.data(), &QCoreApplication::quit);
@@ -44,8 +64,10 @@ Q_DECL_EXPORT int main(int argc, char *argv[])
         view->resize(480, 854);
         view->rootObject()->setProperty("_desktop", true);
         view->show();
+        CAMERA_STARTUP_MARK("lockscreen-app", startupTimer, "desktop window shown");
     } else {
         view->showFullScreen();
+        CAMERA_STARTUP_MARK("lockscreen-app", startupTimer, "fullscreen window shown");
     }
 
     return app->exec();

--- a/src/capture/CaptureView.qml
+++ b/src/capture/CaptureView.qml
@@ -479,11 +479,18 @@ FocusScope {
         property var backFacingCameras
 
         // On some adaptations media booster makes camera initialization fail
-        // and Camera must be reloaded, try to do that once when that happens
-        property bool needsReload: camera.errorCode === Camera.CameraError
-                                   || (camera.cameraState === Camera.UnloadedState
-                                       && camera.cameraStatus === Camera.UnloadedStatus)
+        // and Camera must be reloaded, try to do that once when that happens.
+        // Wait until the Camera item has completed and activation has been
+        // requested before checking so its construction-time default
+        // UnloadedState/UnloadedStatus is not treated as a reload failure.
+        property bool reloadCheckEnabled
+        property bool needsReload: reloadCheckEnabled
+                                   && captureView.effectiveActive
+                                   && (camera.errorCode === Camera.CameraError
+                                       || (camera.cameraState === Camera.UnloadedState
+                                           && camera.cameraStatus === Camera.UnloadedStatus))
 
+        Component.onCompleted: reloadCheckEnabled = true
 
         onErrorCodeChanged: {
             if (errorCode == Camera.CameraError) {


### PR DESCRIPTION
Add opt-in CAMERA_STARTUP launch timing for the normal and lockscreen camera entry points so startup regressions can be measured without noisy logs by default.

Clear a stale unloaded flag during cold CaptureView startup, allowing the camera item to activate normally after a fresh launch.